### PR TITLE
Add extensions and docstrings options

### DIFF
--- a/.github/workflows/Check.yml
+++ b/.github/workflows/Check.yml
@@ -36,3 +36,37 @@ jobs:
           format_files: true
         continue-on-error: true
       - run: grep -q "1 + 1" src/check.jl
+  runic-extensions:
+    name: Runic markdown extensions
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: julia-actions/cache@v2
+      - run: |
+          printf '```julia\n1+1\n```\n' > test.md
+          git add test.md
+          grep -q "1+1" test.md
+      - uses: ./
+        with:
+          version: 'master'
+          extensions: 'jl,md'
+          format_files: true
+        continue-on-error: true
+      - run: grep -q "1 + 1" test.md
+  runic-docstrings:
+    name: Runic docstrings
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: julia-actions/cache@v2
+      - run: |
+          printf '"""\n```julia\n1+1\n```\n"""\nfunction foo() end\n' > test.jl
+          git add test.jl
+          grep -q "1+1" test.jl
+      - uses: ./
+        with:
+          version: 'master'
+          docstrings: true
+          format_files: true
+        continue-on-error: true
+      - run: grep -q "1 + 1" test.jl

--- a/README.md
+++ b/README.md
@@ -114,6 +114,12 @@ jobs:
     # Please see the note above about Runic's version policy.
     # By default runic-action@v1 uses the latest release in the v1 release series.
     version: '1'
+    # Comma-separated list of file extensions to format.
+    # Requires Runic >= 1.7 for markdown support.
+    extensions: 'jl'
+    # When `true`, format Julia code blocks in docstrings.
+    # Requires Runic >= 1.7.
+    docstrings: false
     # When `true`, format the files and leave the repository dirty (in addition to running
     # the usual check). Note that the exit code of the step is still the exit code of check.
     format_files: false

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,6 @@
 ---
 name: 'runic-action'
-description: 'Run the Runic.jl code formatter on Julia files'
+description: 'Run the Runic.jl code formatter on Julia source files and embedded Julia blocks in Markdown files'
 branding:
   icon: "book"
   color: "black"
@@ -8,6 +8,12 @@ inputs:
   version:
     description: 'Runic.jl version number or commit hash'
     default: "1"
+  extensions:
+    description: 'Comma-separated list of file extensions to check (e.g. "jl", "jl,md") (requires Runic >= 1.7)'
+    default: "jl"
+  docstrings:
+    description: 'Whether to format Julia code blocks in docstrings (requires Runic >= 1.7)'
+    default: "false"
   format_files:
     description: 'Whether to format files or not (in addition to checking)'
     default: "false"
@@ -28,4 +34,6 @@ runs:
       run: |
         julia --color=yes --project=@runic "${GITHUB_ACTION_PATH}/src/check.jl"
       env:
+        INPUT_RUNIC_EXTENSIONS: ${{ inputs.extensions }}
+        INPUT_RUNIC_DOCSTRINGS: ${{ inputs.docstrings }}
         INPUT_RUNIC_FORMAT_FILES: ${{ inputs.format_files }}

--- a/src/check.jl
+++ b/src/check.jl
@@ -3,17 +3,30 @@
 using Runic
 
 function main()
-    # Find all *.jl files in the repo
-    julia_files = readlines(`git ls-files -- '*.jl'`)
-    if isempty(julia_files)
-        println("Runic action: No files with `.jl` extension found in repo. Exiting.")
+    # Parse extensions from input
+    extensions_str = get(ENV, "INPUT_RUNIC_EXTENSIONS", "jl")
+    extensions = filter(!isempty, strip.(split(extensions_str, ",")))
+    if isempty(extensions)
+        extensions = ["jl"]
+    end
+    # Find all files matching the extensions
+    patterns = ["*." * ext for ext in extensions]
+    files = readlines(`git ls-files -- $patterns`)
+    if isempty(files)
+        exts = join(("." * ext for ext in extensions), ", ", ", and ")
+        println("Runic action: No files with $exts extension(s) found in repo. Exiting.")
         return 0
     end
+    # Build common flags
+    common_flags = String[]
+    if get(ENV, "INPUT_RUNIC_DOCSTRINGS", "false") == "true"
+        push!(common_flags, "--docstrings")
+    end
     # Run Runic.main
-    rc = Runic.main(append!(["--check", "--diff", "--verbose"], julia_files))
+    rc = Runic.main(append!(append!(["--check", "--diff", "--verbose"], common_flags), files))
     # Format files, and leave the the repo dirty, if requested
     if rc != 0 && get(ENV, "INPUT_RUNIC_FORMAT_FILES", "false") == "true"
-        rc2 = Runic.main(append!(["--inplace"], julia_files))
+        rc2 = Runic.main(append!(append!(["--inplace"], common_flags), files))
         rc = max(rc, rc2)
     end
     return rc


### PR DESCRIPTION
Add two new inputs for features introduced in Runic v1.7:
- `extensions`: configurable file extensions (e.g. "jl,md" for markdown support)
- `docstrings`: opt-in formatting of Julia code blocks in docstrings